### PR TITLE
Fix benchmark for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS On)
 option(RL_BUILD_BENCHMARKS "Build benchmarks" OFF)
 if(RL_BUILD_BENCHMARKS)
   list(APPEND VCPKG_MANIFEST_FEATURES "benchmarks")
+  # benchmark needs to be 1.7.1 or higher.  1.7.1 of benchmark fixes windows build issues
+  list(APPEND VCPKG_OVERLAY_PORTS ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg-overlay/ports)
 endif()
 
 project(reinforcement_learning)

--- a/benchmarks/benchmark_cb_v2.cc
+++ b/benchmarks/benchmark_cb_v2.cc
@@ -51,8 +51,8 @@ static void bench_cb(benchmark::State& state, ExtraArgs&&... extra_args)
   config.set(r::name::MODEL_SRC, r::value::NO_MODEL_DATA);
   config.set(r::name::OBSERVATION_SENDER_IMPLEMENTATION, r::value::OBSERVATION_FILE_SENDER);
   config.set(r::name::INTERACTION_SENDER_IMPLEMENTATION, r::value::INTERACTION_FILE_SENDER);
-  config.set(r::name::INTERACTION_FILE_NAME, "/dev/null");
-  config.set(r::name::OBSERVATION_FILE_NAME, "/dev/null");
+  config.set(r::name::INTERACTION_FILE_NAME, r::DEV_NULL);
+  config.set(r::name::OBSERVATION_FILE_NAME, r::DEV_NULL);
   config.set(r::name::MODEL_BACKGROUND_REFRESH, "false");
   // config.set(r::name::MODEL_IMPLEMENTATION, r::value::PASSTHROUGH_PDF_MODEL);
   config.set(r::name::VW_POOL_INIT_SIZE, "1");

--- a/benchmarks/benchmark_ccb.cc
+++ b/benchmarks/benchmark_ccb.cc
@@ -57,8 +57,8 @@ static void bench_ccb(benchmark::State& state, ExtraArgs&&... extra_args)
   config.set(r::name::MODEL_FILE_MUST_EXIST, "true");
   config.set(r::name::OBSERVATION_SENDER_IMPLEMENTATION, r::value::OBSERVATION_FILE_SENDER);
   config.set(r::name::INTERACTION_SENDER_IMPLEMENTATION, r::value::INTERACTION_FILE_SENDER);
-  config.set(r::name::INTERACTION_FILE_NAME, "/dev/null");
-  config.set(r::name::OBSERVATION_FILE_NAME, "/dev/null");
+  config.set(r::name::INTERACTION_FILE_NAME, r::DEV_NULL);
+  config.set(r::name::OBSERVATION_FILE_NAME, r::DEV_NULL);
   config.set(r::name::MODEL_BACKGROUND_REFRESH, "false");
   config.set(r::name::VW_POOL_INIT_SIZE, "1");
   config.set(r::name::INTERACTION_USE_COMPRESSION, compression ? "true" : "false");
@@ -125,7 +125,7 @@ static void bench_ccb(benchmark::State& state, ExtraArgs&&... extra_args)
 }
 
 BENCHMARK_CAPTURE(bench_ccb, ccb_adf_diff_char_interactions_predict,
-    10,     // number of examples
+    1,     // number of examples
     30,     // shared_feats_size
     20,     // shared_feats_count (actual number of shared features in example)
     30,     // action_feats_size

--- a/include/constants.h
+++ b/include/constants.h
@@ -4,8 +4,10 @@ namespace reinforcement_learning
 {
 #ifdef _WIN32
 const char* const PATH_DELIMITER = "\\";
+const char* const DEV_NULL = "nul";
 #else
 const char* const PATH_DELIMITER = "/";
+const char* const DEV_NULL = "/dev/null";
 #endif
 
 namespace name

--- a/test_tools/example_gen/example_gen.cc
+++ b/test_tools/example_gen/example_gen.cc
@@ -78,11 +78,11 @@ void load_config_from_json(int action, u::configuration& config, bool enable_app
     if (is_observation)
     {
       config.set("observation.file.name", file_name.c_str());
-      config.set("interaction.file.name", "/dev/null");
+      config.set("interaction.file.name", r::DEV_NULL);
     }
     else
     {
-      config.set("observation.file.name", "/dev/null");
+      config.set("observation.file.name", r::DEV_NULL);
       config.set("interaction.file.name", file_name.c_str());
     }
   }

--- a/vcpkg-overlay/ports/benchmark/portfile.cmake
+++ b/vcpkg-overlay/ports/benchmark/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/benchmark
+    REF v1.7.1
+    SHA512 396af1c1d3eaa2b78c6d23b1472f6088db85a294056ae1c2366dc5c0becdc8f141ba8fc3a235033324ab0a41c2298f5d242ef09b9b6f69d9877de6bcb2062efd
+    HEAD_REF master
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBENCHMARK_ENABLE_TESTING=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/benchmark)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/vcpkg-overlay/ports/benchmark/vcpkg.json
+++ b/vcpkg-overlay/ports/benchmark/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "$comment": "https://github.com/google/benchmark/issues/661 describes the missing UWP support upstream",
+  "name": "benchmark",
+  "version-semver": "1.7.1",
+  "description": "A library to support the benchmarking of functions, similar to unit-tests.",
+  "homepage": "https://github.com/google/benchmark",
+  "license": "Apache-2.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -26,7 +26,7 @@
   "features": {
     "benchmarks": {
       "description": "Build Benchmarks",
-      "dependencies": ["benchmark"]
+      "dependencies": [{"name":"benchmark", "version>=":"1.7.1"}]
     }
   }
 }


### PR DESCRIPTION
1) benchmark version >= 1.7.1 .  There are bug fixes for windows link issues in 1.7.1
2) Windows does not support writing to /dev/null 